### PR TITLE
Feature/sas 15931/id

### DIFF
--- a/modules/azerionedgeRtdProvider.js
+++ b/modules/azerionedgeRtdProvider.js
@@ -212,6 +212,7 @@ export const azerionedgeSubmodule = {
   name: SUBREAL_TIME_MODULE,
   init: init,
   getBidRequestData: getBidRequestData,
+  gvlid: IMPROVEDIGITAL_GVLID,
 };
 
 submodule(REAL_TIME_MODULE, azerionedgeSubmodule);

--- a/test/spec/modules/azerionedgeRtdProvider_spec.js
+++ b/test/spec/modules/azerionedgeRtdProvider_spec.js
@@ -40,7 +40,7 @@ describe('Azerion Edge RTD submodule', function () {
     });
 
     it('should have the correct gvlid', () => {
-      expect(returned.gvlid).toEqual(IMPROVEDIGITAL_GVLID);
+      expect(returned.gvlid).to.equal(IMPROVEDIGITAL_GVLID);
     });
 
     it('should return true', function () {

--- a/test/spec/modules/azerionedgeRtdProvider_spec.js
+++ b/test/spec/modules/azerionedgeRtdProvider_spec.js
@@ -8,7 +8,7 @@ describe('Azerion Edge RTD submodule', function () {
     { id: '1', visits: 123 },
     { id: '2', visits: 456 },
   ];
-
+  const IMPROVEDIGITAL_GVLID = '253';
   const key = 'publisher123';
   const bidders = ['appnexus', 'improvedigital'];
   const process = { key: 'value' };
@@ -37,6 +37,10 @@ describe('Azerion Edge RTD submodule', function () {
 
     beforeEach(function () {
       returned = azerionedgeRTD.azerionedgeSubmodule.init(dataProvider, ignoreConsent);
+    });
+
+    it('should have the correct gvlid', () => {
+      expect(returned.gvlid).toEqual(IMPROVEDIGITAL_GVLID);
     });
 
     it('should return true', function () {

--- a/test/spec/modules/azerionedgeRtdProvider_spec.js
+++ b/test/spec/modules/azerionedgeRtdProvider_spec.js
@@ -40,7 +40,9 @@ describe('Azerion Edge RTD submodule', function () {
     });
 
     it('should have the correct gvlid', () => {
-      expect(returned.gvlid).to.equal(IMPROVEDIGITAL_GVLID);
+      expect(azerionedgeRTD.azerionedgeSubmodule.gvlid).to.equal(
+        IMPROVEDIGITAL_GVLID
+      );
     });
 
     it('should return true', function () {


### PR DESCRIPTION
<!--
Thank you for your pull request! 

Please title your pull request like this: 'Module: Change', eg 'Fraggles Bid Adapter: support fragglerock'

Please make sure this PR is scoped to one change or you may be asked to resubmit. 
 
Please make sure any added or changed code includes tests with greater than 80% code coverage. 

See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.

For any user facing change, submit a link to a PR on the docs repo at https://github.com/prebid/prebid.github.io/
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [ ] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: also submit your bidder parameter documentation as noted in https://docs.prebid.org/dev-docs/bidder-adaptor.html#submitting-your-adapter -->
- [ ] Updated bidder adapter  <!--  IMPORTANT: (1) consider whether you need to upgrade your bidder parameter documentation in https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders and (2) if you have a Prebid Server adapter, please consider whether that should be updated as well. --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
<!-- Describe the change proposed in this pull request -->

<!-- For new bidder adapters, please provide the following
- contact email of the adapter’s maintainer
- test parameters for validating bids:
```
{
  bidder: '<bidder name>',
  params: {
    // ...
  }
}
```

Be sure to test the integration with your adserver using the [Hello World](/integrationExamples/gpt/hello_world.html) sample page. -->


## Other information
<!-- References to related PR or issue #s, @mentions of the person or team responsible for reviewing changes, etc. -->
